### PR TITLE
Condense Enclosure System and allow multiple start locations

### DIFF
--- a/Space-Zoologist/Assets/SaveData.meta
+++ b/Space-Zoologist/Assets/SaveData.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: cf90a480475156a4193f71370495d421
+guid: d62dea571454d174b8eb21713fb9cab3
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/Space-Zoologist/Assets/SaveData/Grid.meta
+++ b/Space-Zoologist/Assets/SaveData/Grid.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 2f5e6e3931e7f8d4fbd5e0d344bcfcd2
+guid: cdc2d493c71d7814dbedb5188746a947
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/Space-Zoologist/Assets/Scenes/Level2E1.unity
+++ b/Space-Zoologist/Assets/Scenes/Level2E1.unity
@@ -33422,6 +33422,9 @@ MonoBehaviour:
   TileSystem: {fileID: 765609361}
   needSystemManager: {fileID: 8743428314032458836}
   gridSystem: {fileID: 1621202152}
+  startingPositions:
+  - {x: 7, y: 6, z: 0}
+  - {x: 19, y: 19, z: 0}
 --- !u!4 &6874327555454712159
 Transform:
   m_ObjectHideFlags: 0

--- a/Space-Zoologist/Assets/Scenes/Testing.meta
+++ b/Space-Zoologist/Assets/Scenes/Testing.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 9c8d0554d8d2dd2469e122b4f8efeb5f
+guid: d7458cd1ae5cd41f8bda1db9340a86df
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/Space-Zoologist/Assets/Scripts/GameData.meta
+++ b/Space-Zoologist/Assets/Scripts/GameData.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 592eba8783f0be64d8fe98b9ad62ab22
+guid: 34be2c593ee7540e489c4e17c6ae7969
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/Space-Zoologist/Assets/Scripts/Species.meta
+++ b/Space-Zoologist/Assets/Scripts/Species.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 3f7079a074ca5b743b8ad8bd8623fcb1
+guid: 7d5991b80a9e54d8fa55abbfa04999f9
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/Space-Zoologist/Assets/Scripts/Time.meta
+++ b/Space-Zoologist/Assets/Scripts/Time.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: bc8e215f987e44d09987d46cc1dfd296
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Space-Zoologist/Assets/Scripts/UI/Inspector/Inspector.cs
+++ b/Space-Zoologist/Assets/Scripts/UI/Inspector/Inspector.cs
@@ -327,9 +327,9 @@ public class Inspector : MonoBehaviour
 
     private void DisplayAreaText(Vector3Int cellPos)
     {
+        //Debug.Log($"Enclosed are @ {cellPos} selected");
         this.enclosureSystem.UpdateEnclosedAreas();
         this.inspectorWindowDisplayScript.DislplayEnclosedArea(this.enclosureSystem.GetEnclosedAreaByCellPosition(cellPos));
-        //Debug.Log($"Enclosed are @ {cellPos} selected");
     }
 
     private void DisplayLiquidText(Vector3Int cellPos)


### PR DESCRIPTION
- Added a list of vector3int on enclosure system that serves as starting locations for enclosures. If left empty it uses gridSystem.startTile (same as before)

- Merged FindEnclosedAreas() and UpdateEnclosedAreas as they contain large chunks of duplicate code. Now they become UpdateEnclosedAreas(bool isUpdate = true). No changes should be needed on other systems since FindEnclosedAreas() is only called by Enclosure system on start.

<img width="1008" alt="Screen Shot 2021-08-11 at 4 34 04 AM" src="https://user-images.githubusercontent.com/24749416/128932454-8b721b5d-77e6-433b-b58c-7958881b7f1e.png">
<img width="1008" alt="Screen Shot 2021-08-11 at 4 33 58 AM" src="https://user-images.githubusercontent.com/24749416/128932439-634799e7-6cc4-4973-a292-8fe7c507d72d.png">
