### PR TITLE
Food sources can now be in the level without having to be in the shop

### DIFF
--- a/Space-Zoologist/Assets/Scripts/Managers/GameManager.cs
+++ b/Space-Zoologist/Assets/Scripts/Managers/GameManager.cs
@@ -198,17 +198,7 @@ public class GameManager : MonoBehaviour
         // set the food source dictionary
         foreach (FoodSourceSpecies foodSource in m_levelData.FoodSourceSpecies)
         {
-            foreach (LevelData.ItemData data in m_levelData.ItemQuantities)
-            {
-                Item item = data.itemObject;
-                if (item)
-                {
-                    if (item.Type.Equals(ItemType.Food) && item.ID.Equals(foodSource.SpeciesName) && !FoodSources.ContainsKey(item.ID))
-                    {
-                        this.FoodSources.Add(item.ID, foodSource);
-                    }
-                }
-            }
+            this.FoodSources.Add(foodSource.SpeciesName, foodSource);
         }
 
         // set the animal dictionary


### PR DESCRIPTION
Fixes a bug where a foodspecies had to be in the shop to get loaded (would prevent foodspecies from appearing in the level if they weren't also purchasable)