### PR TITLE
Build UI

### DIFF
--- a/Space-Zoologist/Assets/Prefabs/UI/Store/Item Cell.prefab
+++ b/Space-Zoologist/Assets/Prefabs/UI/Store/Item Cell.prefab
@@ -11,6 +11,7 @@ GameObject:
   - component: {fileID: 4773056711100217957}
   - component: {fileID: 8909592495270159342}
   - component: {fileID: 5147190495597548658}
+  - component: {fileID: 2319473493262063846}
   m_Layer: 5
   m_Name: Item Cell
   m_TagString: Untagged
@@ -70,6 +71,35 @@ MonoBehaviour:
   RemainingAmountText: {fileID: 1259958492504397446}
   Cost: {fileID: 6186097169190421582}
   RemainingAmount: -1
+--- !u!114 &2319473493262063846
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 350285113092910437}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.3529412, g: 0.34509805, b: 0.6901961, a: 1}
+  m_RaycastTarget: 1
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 51bdd19b404bcff4184919defab7ecbc, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 3
 --- !u!1 &504285917637353408
 GameObject:
   m_ObjectHideFlags: 0

--- a/Space-Zoologist/Assets/Resources/ItemRegistry.asset
+++ b/Space-Zoologist/Assets/Resources/ItemRegistry.asset
@@ -56,7 +56,7 @@ MonoBehaviour:
   - list:
     - name:
         names:
-        - Mapel Tree
+        - Maple Tree
         - Astral Maple
         - Candentis Acernis
       icon: {fileID: 21300000, guid: 559391e3afd534d628fb52b7de153887, type: 3}

--- a/Space-Zoologist/Assets/Resources/ItemRegistry.asset
+++ b/Space-Zoologist/Assets/Resources/ItemRegistry.asset
@@ -1,0 +1,147 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 99daf844d8425ae4891c5419dcc0675a, type: 3}
+  m_Name: ItemRegistry
+  m_EditorClassIdentifier: 
+  itemDatas:
+  - list:
+    - name:
+        names:
+        - Goat
+        - Zeig
+        - CapraX Zeigrun
+      icon: {fileID: -2660005681641717123, guid: 69e7603fc8d1441cf8cb64f8bd8fc5a8,
+        type: 3}
+    - name:
+        names:
+        - Cow
+        - Star Cow
+        - Eligans Impar
+      icon: {fileID: -4745029855743570903, guid: a65138aa083a64824863dfffd99c3ddb,
+        type: 3}
+    - name:
+        names:
+        - Anteater
+        - Stroteater
+        - Ligurio Vermis
+      icon: {fileID: -211078723010820832, guid: 9e0ec41a9624140599e268bb1cc2d0e3,
+        type: 3}
+    - name:
+        names:
+        - Spider
+        - Strot
+        - Thalassius Succo
+      icon: {fileID: 0}
+    - name:
+        names:
+        - Slug
+        - Flan
+        - Humidum Limax
+      icon: {fileID: 0}
+    - name:
+        names:
+        - Momo
+        - Mimi
+        - Lemuroidea Empathicus
+      icon: {fileID: 0}
+  - list:
+    - name:
+        names:
+        - Mapel Tree
+        - Astral Maple
+        - Candentis Acernis
+      icon: {fileID: 21300000, guid: 559391e3afd534d628fb52b7de153887, type: 3}
+    - name:
+        names:
+        - Golden Maple Tree
+        - Gilded Astral Maple
+        - Candentis Acernis Aurum
+      icon: {fileID: 0}
+    - name:
+        names:
+        - Berry Bush
+        - Bacca Bush
+        - Vaccinum Spatium Bacca
+      icon: {fileID: 21300000, guid: df56bb4276e974d30a3872e0d998f083, type: 3}
+    - name:
+        names:
+        - Mushroom
+        - Glowcaps
+        - Boletus Anceps
+      icon: {fileID: 21300000, guid: 6ad7400d4524245f89f5b613637e4fad, type: 3}
+    - name:
+        names:
+        - Kelp
+        - Flanweed
+        - Coruscent Laminar
+      icon: {fileID: 21300000, guid: 0bd64091a7a6746179fd96837aecb8d6, type: 3}
+    - name:
+        names:
+        - Ant Colony
+        - Formica Hive
+        - Formica Collis
+      icon: {fileID: 21300000, guid: 090d3a8a52d514b058cfc022ea335109, type: 3}
+  - list:
+    - name:
+        names:
+        - Dirt
+        - Dirt
+        - Dirt
+      icon: {fileID: 0}
+    - name:
+        names:
+        - Grass
+        - Grass
+        - Grass
+      icon: {fileID: 0}
+    - name:
+        names:
+        - Rock
+        - Rock
+        - Rock
+      icon: {fileID: 0}
+    - name:
+        names:
+        - Sand
+        - Sand
+        - Sand
+      icon: {fileID: 0}
+    - name:
+        names:
+        - Swamp
+        - Swamp
+        - Swamp
+      icon: {fileID: 0}
+    - name:
+        names:
+        - Wall
+        - Wall
+        - Wall
+      icon: {fileID: 0}
+    - name:
+        names:
+        - Fresh Water
+        - Fresh Water
+        - Fresh Water
+      icon: {fileID: 0}
+    - name:
+        names:
+        - Salt Water
+        - Salt Water
+        - Salt Water
+      icon: {fileID: 0}
+    - name:
+        names:
+        - Stagnant Water
+        - Stagnant Water
+        - Stagnant Water
+      icon: {fileID: 0}

--- a/Space-Zoologist/Assets/Resources/ItemRegistry.asset.meta
+++ b/Space-Zoologist/Assets/Resources/ItemRegistry.asset.meta
@@ -1,8 +1,8 @@
 fileFormatVersion: 2
-guid: 2f5e6e3931e7f8d4fbd5e0d344bcfcd2
-folderAsset: yes
-DefaultImporter:
+guid: 464082c6edc969142ad9a69a65bd973a
+NativeFormatImporter:
   externalObjects: {}
+  mainObjectFileID: 0
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Space-Zoologist/Assets/ScriptableObjects/Food Sources/Shop Items/AntsItem.asset
+++ b/Space-Zoologist/Assets/ScriptableObjects/Food Sources/Shop Items/AntsItem.asset
@@ -12,6 +12,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: eb43224d6f3ee97448552e334a6e0c8f, type: 3}
   m_Name: AntsItem
   m_EditorClassIdentifier: 
+  itemID:
+    category: 1
+    index: 5
   id: Ants
   type: 0
   itemName: Ants

--- a/Space-Zoologist/Assets/ScriptableObjects/Food Sources/Shop Items/BerriesItem.asset
+++ b/Space-Zoologist/Assets/ScriptableObjects/Food Sources/Shop Items/BerriesItem.asset
@@ -12,6 +12,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: eb43224d6f3ee97448552e334a6e0c8f, type: 3}
   m_Name: BerriesItem
   m_EditorClassIdentifier: 
+  itemID:
+    category: 1
+    index: 2
   id: Berries
   type: 0
   itemName: Berries

--- a/Space-Zoologist/Assets/ScriptableObjects/Food Sources/Shop Items/GoldSpaceMapleItem.asset
+++ b/Space-Zoologist/Assets/ScriptableObjects/Food Sources/Shop Items/GoldSpaceMapleItem.asset
@@ -12,6 +12,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: eb43224d6f3ee97448552e334a6e0c8f, type: 3}
   m_Name: GoldSpaceMapleItem
   m_EditorClassIdentifier: 
+  itemID:
+    category: 1
+    index: 1
   id: Gold Space Maple
   type: 0
   itemName: Gold Space Maple

--- a/Space-Zoologist/Assets/ScriptableObjects/Food Sources/Shop Items/KelpItem.asset
+++ b/Space-Zoologist/Assets/ScriptableObjects/Food Sources/Shop Items/KelpItem.asset
@@ -12,6 +12,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: eb43224d6f3ee97448552e334a6e0c8f, type: 3}
   m_Name: KelpItem
   m_EditorClassIdentifier: 
+  itemID:
+    category: 1
+    index: 4
   id: Kelp
   type: 0
   itemName: Kelp

--- a/Space-Zoologist/Assets/ScriptableObjects/Food Sources/Shop Items/MushroomItem.asset
+++ b/Space-Zoologist/Assets/ScriptableObjects/Food Sources/Shop Items/MushroomItem.asset
@@ -12,6 +12,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: eb43224d6f3ee97448552e334a6e0c8f, type: 3}
   m_Name: MushroomItem
   m_EditorClassIdentifier: 
+  itemID:
+    category: 1
+    index: 3
   id: Mushrooms
   type: 0
   itemName: Mushrooms

--- a/Space-Zoologist/Assets/ScriptableObjects/Food Sources/Shop Items/SpaceMapleItem.asset
+++ b/Space-Zoologist/Assets/ScriptableObjects/Food Sources/Shop Items/SpaceMapleItem.asset
@@ -12,6 +12,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: eb43224d6f3ee97448552e334a6e0c8f, type: 3}
   m_Name: SpaceMapleItem
   m_EditorClassIdentifier: 
+  itemID:
+    category: 1
+    index: 0
   id: Space Maple
   type: 0
   itemName: Space Maple

--- a/Space-Zoologist/Assets/ScriptableObjects/Species/Shop Items/AnteaterItem.asset
+++ b/Space-Zoologist/Assets/ScriptableObjects/Species/Shop Items/AnteaterItem.asset
@@ -12,6 +12,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: eb43224d6f3ee97448552e334a6e0c8f, type: 3}
   m_Name: AnteaterItem
   m_EditorClassIdentifier: 
+  itemID:
+    category: 0
+    index: 2
   id: Ligurio Vermis
   type: 3
   itemName: Ligurio Vermis

--- a/Space-Zoologist/Assets/ScriptableObjects/Species/Shop Items/CowItem.asset
+++ b/Space-Zoologist/Assets/ScriptableObjects/Species/Shop Items/CowItem.asset
@@ -12,6 +12,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: eb43224d6f3ee97448552e334a6e0c8f, type: 3}
   m_Name: CowItem
   m_EditorClassIdentifier: 
+  itemID:
+    category: 0
+    index: 1
   id: Eligans Impar
   type: 3
   itemName: Eligans Impar

--- a/Space-Zoologist/Assets/ScriptableObjects/Species/Shop Items/SlugItem.asset
+++ b/Space-Zoologist/Assets/ScriptableObjects/Species/Shop Items/SlugItem.asset
@@ -12,6 +12,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: eb43224d6f3ee97448552e334a6e0c8f, type: 3}
   m_Name: SlugItem
   m_EditorClassIdentifier: 
+  itemID:
+    category: 0
+    index: 4
   id: Humidum Limax
   type: 3
   itemName: Humidum Limax

--- a/Space-Zoologist/Assets/ScriptableObjects/Species/Shop Items/SpiderItem.asset
+++ b/Space-Zoologist/Assets/ScriptableObjects/Species/Shop Items/SpiderItem.asset
@@ -12,6 +12,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: eb43224d6f3ee97448552e334a6e0c8f, type: 3}
   m_Name: SpiderItem
   m_EditorClassIdentifier: 
+  itemID:
+    category: 0
+    index: 3
   id: Thalassius Succo
   type: 3
   itemName: Thalassius Succo

--- a/Space-Zoologist/Assets/ScriptableObjects/Tiles/Dirt.asset
+++ b/Space-Zoologist/Assets/ScriptableObjects/Tiles/Dirt.asset
@@ -12,6 +12,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: eb43224d6f3ee97448552e334a6e0c8f, type: 3}
   m_Name: Dirt
   m_EditorClassIdentifier: 
+  itemID:
+    category: 2
+    index: 0
   id: Dirt
   type: 1
   itemName: Dirt

--- a/Space-Zoologist/Assets/ScriptableObjects/Tiles/FreshWater.asset
+++ b/Space-Zoologist/Assets/ScriptableObjects/Tiles/FreshWater.asset
@@ -12,6 +12,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 857335ca450634d41951df7ce9e84e43, type: 3}
   m_Name: FreshWater
   m_EditorClassIdentifier: 
+  itemID:
+    category: 2
+    index: 6
   id: Liquid
   type: 1
   itemName: Fresh Water

--- a/Space-Zoologist/Assets/ScriptableObjects/Tiles/Grass.asset
+++ b/Space-Zoologist/Assets/ScriptableObjects/Tiles/Grass.asset
@@ -12,6 +12,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: eb43224d6f3ee97448552e334a6e0c8f, type: 3}
   m_Name: Grass
   m_EditorClassIdentifier: 
+  itemID:
+    category: 2
+    index: 1
   id: Grass
   type: 1
   itemName: Grass

--- a/Space-Zoologist/Assets/ScriptableObjects/Tiles/SaltWater.asset
+++ b/Space-Zoologist/Assets/ScriptableObjects/Tiles/SaltWater.asset
@@ -12,6 +12,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 857335ca450634d41951df7ce9e84e43, type: 3}
   m_Name: SaltWater
   m_EditorClassIdentifier: 
+  itemID:
+    category: 2
+    index: 7
   id: Liquid
   type: 1
   itemName: Salt Water

--- a/Space-Zoologist/Assets/ScriptableObjects/Tiles/Sand.asset
+++ b/Space-Zoologist/Assets/ScriptableObjects/Tiles/Sand.asset
@@ -12,6 +12,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: eb43224d6f3ee97448552e334a6e0c8f, type: 3}
   m_Name: Sand
   m_EditorClassIdentifier: 
+  itemID:
+    category: 2
+    index: 3
   id: Sand
   type: 1
   itemName: Sand

--- a/Space-Zoologist/Assets/ScriptableObjects/Tiles/StagnantWater.asset
+++ b/Space-Zoologist/Assets/ScriptableObjects/Tiles/StagnantWater.asset
@@ -12,6 +12,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 857335ca450634d41951df7ce9e84e43, type: 3}
   m_Name: StagnantWater
   m_EditorClassIdentifier: 
+  itemID:
+    category: 2
+    index: 8
   id: Liquid
   type: 1
   itemName: Stagnant Water

--- a/Space-Zoologist/Assets/ScriptableObjects/Tiles/Stone.asset
+++ b/Space-Zoologist/Assets/ScriptableObjects/Tiles/Stone.asset
@@ -12,6 +12,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: eb43224d6f3ee97448552e334a6e0c8f, type: 3}
   m_Name: Stone
   m_EditorClassIdentifier: 
+  itemID:
+    category: 2
+    index: 2
   id: Stone
   type: 1
   itemName: Stone

--- a/Space-Zoologist/Assets/ScriptableObjects/Tiles/Swamp.asset
+++ b/Space-Zoologist/Assets/ScriptableObjects/Tiles/Swamp.asset
@@ -12,6 +12,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: eb43224d6f3ee97448552e334a6e0c8f, type: 3}
   m_Name: Swamp
   m_EditorClassIdentifier: 
+  itemID:
+    category: 2
+    index: 4
   id: Swamp
   type: 1
   itemName: Swamp

--- a/Space-Zoologist/Assets/ScriptableObjects/Tiles/Wall.asset
+++ b/Space-Zoologist/Assets/ScriptableObjects/Tiles/Wall.asset
@@ -12,6 +12,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: eb43224d6f3ee97448552e334a6e0c8f, type: 3}
   m_Name: Wall
   m_EditorClassIdentifier: 
+  itemID:
+    category: 2
+    index: 5
   id: Wall
   type: 1
   itemName: Wall

--- a/Space-Zoologist/Assets/Scripts/Editor/ArrayFieldWithoutFoldout.cs
+++ b/Space-Zoologist/Assets/Scripts/Editor/ArrayFieldWithoutFoldout.cs
@@ -1,0 +1,46 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEditor;
+
+public static class ArrayFieldWithoutFoldout
+{
+    #region Custom Property Drawer Helpers
+    public static void OnGUI(Rect position, SerializedProperty array, GUIContent label)
+    {
+        // Set height for jsut one control
+        position.height = EditorExtensions.StandardControlHeight;
+
+        // Layout the array size
+        EditorGUI.PropertyField(position, array.FindPropertyRelative("Array.size"), label);
+        position.y += position.height;
+
+        for (int i = 0; i < array.arraySize; i++)
+        {
+            // Get the element to edit
+            SerializedProperty element = array.GetArrayElementAtIndex(i);
+
+            // Layout this element
+            EditorGUI.PropertyField(position, element);
+            position.y += EditorGUI.GetPropertyHeight(element);
+        }
+    }
+    public static float GetPropertyHeight(SerializedProperty array, GUIContent label)
+    {
+        float height = EditorExtensions.StandardControlHeight;
+
+        // Add heights for all children
+        for (int i = 0; i < array.arraySize; i++)
+        {
+            SerializedProperty element = array.GetArrayElementAtIndex(i);
+            height += EditorGUI.GetPropertyHeight(element);
+        }
+
+        return height;
+    }
+    #endregion
+
+    #region Custom Editor Helpers
+
+    #endregion
+}

--- a/Space-Zoologist/Assets/Scripts/Editor/ArrayFieldWithoutFoldout.cs.meta
+++ b/Space-Zoologist/Assets/Scripts/Editor/ArrayFieldWithoutFoldout.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e7a248a393eab6048b478f68b31afb0a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Space-Zoologist/Assets/Scripts/Editor/EditArrayOnEnum.cs
+++ b/Space-Zoologist/Assets/Scripts/Editor/EditArrayOnEnum.cs
@@ -1,10 +1,12 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.Events;
 using UnityEditor;
 
 public static class EditArrayOnEnum
 {
+    #region Custom Property Drawer Helpers
     public static void OnGUI(Rect position, SerializedProperty list, GUIContent label, System.Type enumType)
     {
         // Set height for only one control
@@ -59,4 +61,38 @@ public static class EditArrayOnEnum
 
         return height;
     }
+    #endregion
+
+    #region Custom Editor Helpers
+    public static void OnInspectorGUI(SerializedProperty list, System.Type enumType)
+    {
+        list.isExpanded = EditorGUILayout.Foldout(list.isExpanded, list.displayName);
+
+        if(list.isExpanded)
+        {
+            EditorGUI.indentLevel++;
+
+            // Get the enum labels and set the length of the list to the length of the enum
+            string[] enumLabels = System.Enum.GetNames(enumType);
+            if (enumLabels.Length != list.arraySize) list.arraySize = enumLabels.Length;
+
+            // Edit each property in the array
+            for (int i = 0; i < list.arraySize; i++)
+            {
+                // Get the current element and setup the element label to be the same as the enum name
+                SerializedProperty element = list.GetArrayElementAtIndex(i);
+                GUIContent elementLabel = new GUIContent(ObjectNames.NicifyVariableName(enumLabels[i]));
+
+                // Edit the element and advance the position down
+                EditorGUILayout.PropertyField(element, elementLabel, true);
+            }
+
+            EditorGUI.indentLevel--;
+        }
+    }
+    public static void OnInspectorGUI<EnumType>(SerializedProperty list)
+    {
+        OnInspectorGUI(list, typeof(EnumType));
+    }
+    #endregion
 }

--- a/Space-Zoologist/Assets/Scripts/Editor/EditorExtensions.cs
+++ b/Space-Zoologist/Assets/Scripts/Editor/EditorExtensions.cs
@@ -1,0 +1,39 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEditor;
+
+public class EditorExtensions
+{
+    #region Public Properties
+    public static float StandardControlHeight => EditorGUIUtility.singleLineHeight + EditorGUIUtility.standardVerticalSpacing;
+    #endregion
+
+    #region Public Methods
+    public static int Popup(Rect position, int index, string[] values, GUIContent label)
+    {
+        position = EditorGUI.PrefixLabel(position, label);
+
+        // Wipe indent so that rects are property placed
+        int oldIndent = EditorGUI.indentLevel;
+        EditorGUI.indentLevel = 0;
+
+        if (values.Length > 0)
+        {
+            // Make sure index is not an invalid value
+            index = Mathf.Clamp(index, 0, values.Length);
+            index = EditorGUI.Popup(position, index, values);
+        }
+        else
+        {
+            EditorGUI.LabelField(position, "Nothing to select");
+            index = -1;
+        }
+
+        // Restore the old indent
+        EditorGUI.indentLevel = oldIndent;
+
+        return index;
+    }
+    #endregion
+}

--- a/Space-Zoologist/Assets/Scripts/Editor/EditorExtensions.cs.meta
+++ b/Space-Zoologist/Assets/Scripts/Editor/EditorExtensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bccfc1632fae5a84f85b8d307eec9f2e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Space-Zoologist/Assets/Scripts/Editor/Items.meta
+++ b/Space-Zoologist/Assets/Scripts/Editor/Items.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 3f7079a074ca5b743b8ad8bd8623fcb1
+guid: f75edcd1fef7df146a80007471df6fbd
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/Space-Zoologist/Assets/Scripts/Editor/Items/ItemDataDrawer.cs
+++ b/Space-Zoologist/Assets/Scripts/Editor/Items/ItemDataDrawer.cs
@@ -1,0 +1,38 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEditor;
+
+[CustomPropertyDrawer(typeof(ItemData))]
+public class ItemDataDrawer : PropertyDrawer
+{
+    public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+    {
+        // Get the array of names
+        SerializedProperty array = property.FindPropertyRelative("name.names");
+
+        // If there are items in the array, then use them to change the content label
+        if (array.arraySize > 0)
+        {
+            // Create a temporary item name and set it up with the values in the serialized property
+            ItemName name = new ItemName();
+            ItemName.Type[] nameTypes = (ItemName.Type[])System.Enum.GetValues(typeof(ItemName.Type));
+
+            // Set each name in the temporary item name object
+            for(int i = 0; i < array.arraySize; i++)
+            {
+                name.Set(nameTypes[i], array.GetArrayElementAtIndex(i).stringValue);
+            }
+
+            // Get the string version of the name
+            label = new GUIContent(name.ToString());
+        }
+
+        // Layout the property with the possibly modified label
+        EditorGUI.PropertyField(position, property, label, true);
+    }
+    public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
+    {
+        return EditorGUI.GetPropertyHeight(property, label);
+    }
+}

--- a/Space-Zoologist/Assets/Scripts/Editor/Items/ItemDataDrawer.cs.meta
+++ b/Space-Zoologist/Assets/Scripts/Editor/Items/ItemDataDrawer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 65ebb447a57404b4bb77213f8cfbd63b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Space-Zoologist/Assets/Scripts/Editor/Items/ItemDataListDrawer.cs
+++ b/Space-Zoologist/Assets/Scripts/Editor/Items/ItemDataListDrawer.cs
@@ -1,0 +1,17 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEditor;
+
+[CustomPropertyDrawer(typeof(ItemDataList))]
+public class ItemDataListDrawer : PropertyDrawer
+{
+    public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+    {
+        EditorGUI.PropertyField(position, property.FindPropertyRelative("list"), label, true);
+    }
+    public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
+    {
+        return EditorGUI.GetPropertyHeight(property.FindPropertyRelative("list"), label, true);
+    }
+}

--- a/Space-Zoologist/Assets/Scripts/Editor/Items/ItemDataListDrawer.cs.meta
+++ b/Space-Zoologist/Assets/Scripts/Editor/Items/ItemDataListDrawer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3bcbc4ad2caaa1244b0a4ac14c7614a3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Space-Zoologist/Assets/Scripts/Editor/Items/ItemIDDrawer.cs
+++ b/Space-Zoologist/Assets/Scripts/Editor/Items/ItemIDDrawer.cs
@@ -1,0 +1,51 @@
+﻿using System.Linq;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEditor;
+
+[CustomPropertyDrawer(typeof(ItemID))]
+public class ItemIDDrawer : PropertyDrawer
+{
+    public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+    {
+        SerializedProperty category = property.FindPropertyRelative(nameof(category));
+        SerializedProperty index = property.FindPropertyRelative(nameof(index));
+
+        // Set height for only one control
+        position.height = EditorExtensions.StandardControlHeight;
+
+        // Add a foldout for the property
+        property.isExpanded = EditorGUI.Foldout(position, property.isExpanded, label);
+        position.y += position.height;
+
+        // If property is expanded the edit other fields
+        if(property.isExpanded)
+        {
+            // Increase indent
+            EditorGUI.indentLevel++;
+
+            // Edit category
+            EditorGUI.PropertyField(position, category);
+            position.y += position.height;
+
+            // Get a list of the items and then a list of their names
+            ItemData[] items = ItemRegistry.GetItemsWithCategory((ItemRegistry.Category)category.intValue);
+            string[] itemNames = items.Select(x =>
+            {
+                if (x.Name != null) return x.Name.ToString();
+                else return "(no name)";
+            }).ToArray();
+
+            // Edit the index as a popup that selects 
+            index.intValue = EditorExtensions.Popup(position, index.intValue, itemNames, new GUIContent(index.displayName));
+
+            // Decrease indent
+            EditorGUI.indentLevel--;
+        }
+    }
+    public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
+    {
+        return EditorGUI.GetPropertyHeight(property, label, true);
+    }
+}

--- a/Space-Zoologist/Assets/Scripts/Editor/Items/ItemIDDrawer.cs.meta
+++ b/Space-Zoologist/Assets/Scripts/Editor/Items/ItemIDDrawer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: db141b655a3469547b7c13cbacd9b7e3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Space-Zoologist/Assets/Scripts/Editor/Items/ItemNameDrawer.cs
+++ b/Space-Zoologist/Assets/Scripts/Editor/Items/ItemNameDrawer.cs
@@ -1,0 +1,17 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEditor;
+
+[CustomPropertyDrawer(typeof(ItemName))]
+public class ItemNameDrawer : PropertyDrawer
+{
+    public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
+    {
+        EditArrayOnEnum.OnGUI<ItemName.Type>(position, property.FindPropertyRelative("names"), label);
+    }
+    public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
+    {
+        return EditArrayOnEnum.GetPropertyHeight(property.FindPropertyRelative("names"), label);
+    }
+}

--- a/Space-Zoologist/Assets/Scripts/Editor/Items/ItemNameDrawer.cs.meta
+++ b/Space-Zoologist/Assets/Scripts/Editor/Items/ItemNameDrawer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 56485ef36ff861d4b971075e44643f53
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Space-Zoologist/Assets/Scripts/Editor/Items/ItemRegistryEditor.cs
+++ b/Space-Zoologist/Assets/Scripts/Editor/Items/ItemRegistryEditor.cs
@@ -1,0 +1,15 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEditor;
+
+[CustomEditor(typeof(ItemRegistry))]
+public class ItemRegistryEditor : Editor
+{
+    public override void OnInspectorGUI()
+    {
+        serializedObject.Update();
+        EditArrayOnEnum.OnInspectorGUI<ItemRegistry.Category>(serializedObject.FindProperty("itemDatas"));
+        serializedObject.ApplyModifiedProperties();
+    }
+}

--- a/Space-Zoologist/Assets/Scripts/Editor/Items/ItemRegistryEditor.cs.meta
+++ b/Space-Zoologist/Assets/Scripts/Editor/Items/ItemRegistryEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 56c1b1fe517cf5d49bec97b289594131
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Space-Zoologist/Assets/Scripts/Items.meta
+++ b/Space-Zoologist/Assets/Scripts/Items.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 592eba8783f0be64d8fe98b9ad62ab22
+guid: d384834a72209864aac6653e2b9fb11b
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/Space-Zoologist/Assets/Scripts/Items/ItemData.cs
+++ b/Space-Zoologist/Assets/Scripts/Items/ItemData.cs
@@ -1,0 +1,21 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+[System.Serializable]
+public class ItemData
+{
+    #region Public Properties
+    public ItemName Name => name;
+    public Sprite Icon => icon;
+    #endregion
+
+    #region Private Editor Fields
+    [SerializeField]
+    [Tooltip("Name used to identify the item")]
+    private ItemName name;
+    [SerializeField]
+    [Tooltip("Icon for this item")]
+    private Sprite icon;
+    #endregion
+}

--- a/Space-Zoologist/Assets/Scripts/Items/ItemData.cs.meta
+++ b/Space-Zoologist/Assets/Scripts/Items/ItemData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7182dc0e7732dd54194dcc15c5a87013
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Space-Zoologist/Assets/Scripts/Items/ItemDataList.cs
+++ b/Space-Zoologist/Assets/Scripts/Items/ItemDataList.cs
@@ -1,0 +1,17 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+[System.Serializable]
+public class ItemDataList
+{
+    #region Public Properties
+    public ItemData[] List => list;
+    #endregion
+
+    #region Private Editor Fields
+    [SerializeField]
+    [Tooltip("List of item datas")]
+    private ItemData[] list;
+    #endregion
+}

--- a/Space-Zoologist/Assets/Scripts/Items/ItemDataList.cs.meta
+++ b/Space-Zoologist/Assets/Scripts/Items/ItemDataList.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c4aa8cbf583367941aeb8ca947a2ba39
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Space-Zoologist/Assets/Scripts/Items/ItemID.cs
+++ b/Space-Zoologist/Assets/Scripts/Items/ItemID.cs
@@ -1,0 +1,21 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+[System.Serializable]
+public struct ItemID
+{
+    #region Public Properties
+    public ItemRegistry.Category Category => category;
+    public int Index => index;
+    #endregion
+
+    #region Private Editor Fields
+    [SerializeField]
+    [Tooltip("Category to select from in the item registry")]
+    private ItemRegistry.Category category;
+    [SerializeField]
+    [Tooltip("Index of the item in the selected category")]
+    private int index;
+    #endregion
+}

--- a/Space-Zoologist/Assets/Scripts/Items/ItemID.cs
+++ b/Space-Zoologist/Assets/Scripts/Items/ItemID.cs
@@ -8,6 +8,7 @@ public struct ItemID
     #region Public Properties
     public ItemRegistry.Category Category => category;
     public int Index => index;
+    public ItemData Data => ItemRegistry.Get(this);
     #endregion
 
     #region Private Editor Fields
@@ -17,5 +18,23 @@ public struct ItemID
     [SerializeField]
     [Tooltip("Index of the item in the selected category")]
     private int index;
+    #endregion
+
+    #region Operators
+    public static bool operator ==(ItemID a, ItemID b) => a.category == b.category && a.index == b.index;
+    public static bool operator !=(ItemID a, ItemID b) => !(a == b);
+    #endregion
+
+    #region Overrides
+    public override bool Equals(object obj)
+    {
+        if (obj == null) return false;
+        else if (obj.GetType() == GetType()) return this == (ItemID)obj;
+        else return false;
+    }
+    public override int GetHashCode()
+    {
+        return category.GetHashCode() + index.GetHashCode();
+    }
     #endregion
 }

--- a/Space-Zoologist/Assets/Scripts/Items/ItemID.cs.meta
+++ b/Space-Zoologist/Assets/Scripts/Items/ItemID.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 48a81a5ac9ae3d246934a112fe1c4cc3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Space-Zoologist/Assets/Scripts/Items/ItemName.cs
+++ b/Space-Zoologist/Assets/Scripts/Items/ItemName.cs
@@ -1,0 +1,38 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+[System.Serializable]
+public class ItemName
+{
+    #region Public Typedefs
+    public enum Type { English, Colloquial, Science }
+    #endregion
+
+    #region Private Editor Fields
+    [SerializeField]
+    [Tooltip("List of names for the item - parallel to the internal 'Type' enum")]
+    private string[] names = { "Goat", "Zeig", "CapraX Zeigrun" };
+    #endregion
+
+    #region Constructors
+    public ItemName()
+    {
+        int totalNames = System.Enum.GetNames(typeof(Type)).Length;
+        names = new string[totalNames];
+    }
+    #endregion
+
+    #region Public Methods
+    public string Get(Type type) => names[(int)type];
+    public string Set(Type type, string name) => names[(int)type] = name;
+    #endregion
+
+    #region Overrides
+    public override string ToString()
+    {
+        if (names != null && names.Length == 3) return names[0] + " (" + names[2] + " or '" + names[1] + "')";
+        else return "(no name)";
+    }
+    #endregion
+}

--- a/Space-Zoologist/Assets/Scripts/Items/ItemName.cs.meta
+++ b/Space-Zoologist/Assets/Scripts/Items/ItemName.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8c0acd380b44815489020d3ac8ded448
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Space-Zoologist/Assets/Scripts/Items/ItemRegistry.cs
+++ b/Space-Zoologist/Assets/Scripts/Items/ItemRegistry.cs
@@ -20,6 +20,12 @@ public class ItemRegistry : ScriptableObjectSingleton<ItemRegistry>
     #endregion
 
     #region Public Methods
+    public static ItemData Get(ItemID id)
+    {
+        ItemData[] datas = GetItemsWithCategory(id.Category);
+        if (id.Index > 0 && id.Index < datas.Length) return datas[id.Index];
+        else return null;
+    }
     public static ItemData[] GetItemsWithCategory(Category category) => Instance.itemDatas[(int)category].List;
     #endregion
 }

--- a/Space-Zoologist/Assets/Scripts/Items/ItemRegistry.cs
+++ b/Space-Zoologist/Assets/Scripts/Items/ItemRegistry.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+[CreateAssetMenu]
+public class ItemRegistry : ScriptableObjectSingleton<ItemRegistry>
+{
+    #region Public Typedefs
+    public enum Category { Species, Food, Tile }
+    #endregion
+
+    #region Private Properties
+    private static ItemRegistry Instance => GetOrCreateInstance(nameof(ItemRegistry), nameof(ItemRegistry));
+    #endregion
+
+    #region Private Editor Fields
+    [SerializeField]
+    [Tooltip("List of item data lists - parallel to the 'Category' enum")]
+    private ItemDataList[] itemDatas;
+    #endregion
+
+    #region Public Methods
+    public static ItemData[] GetItemsWithCategory(Category category) => Instance.itemDatas[(int)category].List;
+    #endregion
+}

--- a/Space-Zoologist/Assets/Scripts/Items/ItemRegistry.cs
+++ b/Space-Zoologist/Assets/Scripts/Items/ItemRegistry.cs
@@ -23,7 +23,7 @@ public class ItemRegistry : ScriptableObjectSingleton<ItemRegistry>
     public static ItemData Get(ItemID id)
     {
         ItemData[] datas = GetItemsWithCategory(id.Category);
-        if (id.Index > 0 && id.Index < datas.Length) return datas[id.Index];
+        if (id.Index >= 0 && id.Index < datas.Length) return datas[id.Index];
         else return null;
     }
     public static ItemData[] GetItemsWithCategory(Category category) => Instance.itemDatas[(int)category].List;

--- a/Space-Zoologist/Assets/Scripts/Items/ItemRegistry.cs.meta
+++ b/Space-Zoologist/Assets/Scripts/Items/ItemRegistry.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 99daf844d8425ae4891c5419dcc0675a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Space-Zoologist/Assets/Scripts/UI/Store/BuildUI.cs
+++ b/Space-Zoologist/Assets/Scripts/UI/Store/BuildUI.cs
@@ -12,7 +12,6 @@ public class BuildUI : MonoBehaviour
     [SerializeField]
     [Tooltip("Button that closes the build UI when clicked")]
     private Button closeButton;
-    public ItemID id;
     #endregion
 
     #region Private Fields

--- a/Space-Zoologist/Assets/Scripts/UI/Store/BuildUI.cs
+++ b/Space-Zoologist/Assets/Scripts/UI/Store/BuildUI.cs
@@ -12,6 +12,7 @@ public class BuildUI : MonoBehaviour
     [SerializeField]
     [Tooltip("Button that closes the build UI when clicked")]
     private Button closeButton;
+    public ItemID id;
     #endregion
 
     #region Private Fields

--- a/Space-Zoologist/Assets/Scripts/UI/Store/Item.cs
+++ b/Space-Zoologist/Assets/Scripts/UI/Store/Item.cs
@@ -7,6 +7,7 @@ public enum ItemType {Food, Terrain, Machine, Pod}
 [CreateAssetMenu(menuName = "Items/Item")]
 public class Item : ScriptableObject
 {
+    public ItemID ItemID => itemID;
     public string ID => id;
     public ItemType Type => type;
     public string ItemName => itemName;
@@ -16,6 +17,7 @@ public class Item : ScriptableObject
     public List<AudioClip> AudioClips => audio;
     public int buildTime => BuildTime;
 
+    [SerializeField] private ItemID itemID = default;
     [SerializeField] private string id = default;
     [SerializeField] private ItemType type = default;
     [SerializeField] private string itemName = default;

--- a/Space-Zoologist/Assets/Scripts/UI/Store/StoreItemCell.cs
+++ b/Space-Zoologist/Assets/Scripts/UI/Store/StoreItemCell.cs
@@ -21,7 +21,7 @@ public class StoreItemCell : MonoBehaviour, IPointerClickHandler, IPointerEnterH
         this.item = item;
         this.itemImage.sprite = item.Icon;
         this.onSelected += itemSelectedHandler;
-        this.ItemName.text = this.item.ItemName;
+        this.ItemName.text = this.item.ItemID.Data.Name.Get(global::ItemName.Type.Colloquial);
         this.Cost.text = ""+this.item.Price;
 
     }

--- a/Space-Zoologist/Assets/Scripts/Y - Utils/ScriptableObjectSingleton.cs
+++ b/Space-Zoologist/Assets/Scripts/Y - Utils/ScriptableObjectSingleton.cs
@@ -1,0 +1,29 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class ScriptableObjectSingleton<BaseType> : ScriptableObject where BaseType : ScriptableObject
+{
+    #region Private Fields
+    private static BaseType instance = null;
+    #endregion
+
+    #region Protected Methods
+    protected static BaseType GetOrCreateInstance(string typename, string path)
+    {
+        if (!instance)
+        {
+            // Load the resource
+            instance = Resources.Load<BaseType>(path);
+
+            // If the instance still could not be loaded then throw an exception
+            if (!instance) throw new MissingReferenceException(
+                typename + ": no instance of type '" + typename +
+                "' could be loaded from the resources folder. Make sure an instance of type " +
+                typename + " exists in the assets folder at the path '" + path + "'");
+        }
+        // If instance is not null return it
+        return instance;
+    }
+    #endregion
+}

--- a/Space-Zoologist/Assets/Scripts/Y - Utils/ScriptableObjectSingleton.cs.meta
+++ b/Space-Zoologist/Assets/Scripts/Y - Utils/ScriptableObjectSingleton.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4976f8f2ea7af9c418c4319ec73c5f5b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Finished the Build UI by displaying the colloquial names of the items instead of their English names, and also added little outlines to item cells like in the UI design.  

This branch comes packaged with a complex ItemRegistry system that you can interface into using an object of type "ItemID", which is more reliable and less error-prone than simple string checking.  However, the ItemRegstry system is currently only being used to get the item's colloquial name for the BuildUI and nothing else, since full use of the system across the board could require a large refactor involving multiple systems (MoveObject, AnimalSpecies, FoodSourceSpecies, GameManager... just to name a few).  In any case, once this is pulled I can use the item registry in the Notebook, so that will be one other thing that uses it.