### PR TITLE
End level bug

### DIFF
--- a/Space-Zoologist/Assets/DialogueEditor/Assets/Scripts/UI/ConversationManager.cs
+++ b/Space-Zoologist/Assets/DialogueEditor/Assets/Scripts/UI/ConversationManager.cs
@@ -395,6 +395,18 @@ namespace DialogueEditor
             SetState(eState.TransitioningDialogueBoxOn);
         }
 
+        public void StartConversationWithoutDeserialization(NPCConversation conversation) {
+
+            m_conversation = conversation.RuntimeLoad();
+            if (OnConversationStarted != null)
+                OnConversationStarted.Invoke();
+
+            TurnOnUI();
+            ClearOptions();
+            m_pendingDialogue = m_conversation.Root;
+            SetState(eState.TransitioningDialogueBoxOn);
+        }
+
         public void EndConversation()
         {
             SetState(eState.TransitioningDialogueOff);

--- a/Space-Zoologist/Assets/Scripts/Quiz/QuizConversation.cs
+++ b/Space-Zoologist/Assets/Scripts/Quiz/QuizConversation.cs
@@ -78,7 +78,7 @@ public class QuizConversation : MonoBehaviour
 
             // Then, say the quiz part of the conversation
             NPCConversation conversation = Create(dialogueManager);
-            dialogueManager.SetNewDialogue(conversation);
+            dialogueManager.SetNewQuiz(conversation);
         }
     }
     public NPCConversation Create(DialogueManager dialogueManager)
@@ -183,7 +183,7 @@ public class QuizConversation : MonoBehaviour
         }
 
         // Serialize the editable conversation back into the NPCConversation and return the result
-        conversation.Serialize(editableConversation);
+        conversation.RuntimeSave(editableConversation);
         return conversation;
     }
     #endregion

--- a/Space-Zoologist/Assets/link.xml
+++ b/Space-Zoologist/Assets/link.xml
@@ -1,0 +1,3 @@
+<linker>
+	<assembly fullname="System.Runtime.Serialization" preserve="all"/>
+</linker>

--- a/Space-Zoologist/Assets/link.xml.meta
+++ b/Space-Zoologist/Assets/link.xml.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: b68612429dab44c4baf01588eca91acc
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Solved end level bug by avoiding to jsonify during runtime.

Details on the bug:
- The error is caused by the call of QuizConversation.Setup(), which calls EditableConversation.Jsonify()

- IL2CPP does code stripping, which means that it ignores and removes unused/unreferenced code
- The EditableConversation.Jsonify() uses DataContractJsonSerializer, which use reflection to access methods that were being stripped, which was causing the null ref error
- This is resolved by adding a link.xml file telling Unity to preserve System.Runtime.Serialization

New Problem arises:
- WebGL does not do just-in-time (run-time) compilation, so it relies on ahead of time compilation (AOT)
- This means it need to determine what to compile before program starts
- The Jsonify function in EditableConversation makes a call to a function with Generic input (int32) that's not compiled by Unity, so it throws an ExecutionEngineException error
- This is usually solved by making an explicit call to the function with specific types, but the function is inaccessible to us due to it being an internal class

Workaround:
- Prevent jsonify during runtime by directly saving the editable conversations