### PR TITLE
Remove Duplicate Function LoadInitialFoods()

### DIFF
--- a/Space-Zoologist/Assets/Scripts/Managers/FoodSourceManager.cs
+++ b/Space-Zoologist/Assets/Scripts/Managers/FoodSourceManager.cs
@@ -20,41 +20,7 @@ public class FoodSourceManager : GridObjectManager
     {
         m_gridSystemReference = GameManager.Instance.m_gridSystem;
     }
-
-    // this used to be part of initialization, but it seems to not be necessary?
-    public void LoadInitialFoods()
-    {
-        // Get all FoodSource at start of level
-        // TODO make use of saved tile
-        GameObject[] foods = GameObject.FindGameObjectsWithTag("FoodSource");
-        foreach (GameObject food in foods)
-        {
-            foodSources.Add(food.GetComponent<FoodSource>());
-            Vector3Int GridPosition = m_gridSystemReference.WorldToCell(food.transform.position);
-
-            m_gridSystemReference.GetTileData(GridPosition).Food = food;
-        }
-
-        // Register Foodsource with NeedSystem via NeedSystemManager
-        foreach (FoodSource foodSource in foodSources)
-        {
-            if (!foodSourcesBySpecies.ContainsKey(foodSource.Species))
-            {
-                foodSourcesBySpecies.Add(foodSource.Species, new List<FoodSource>());
-                foodSourcesBySpecies[foodSource.Species].Add(foodSource);
-            }
-            else
-            {
-                foodSourcesBySpecies[foodSource.Species].Add(foodSource);
-            }
-
-            ((FoodSourceNeedSystem)GameManager.Instance.NeedSystems[NeedType.FoodSource]).AddFoodSource(foodSource);
-            GameManager.Instance.RegisterWithNeedSystems(foodSource);
-            EventManager.Instance.InvokeEvent(EventType.NewFoodSource, foodSource);
-        }
-        //FoodPlacer.PlaceFood();
-    }
-
+    
     // TODO: combine two version into one
     public GameObject CreateFoodSource(FoodSourceSpecies species, Vector2 position, int ttb = -1)
     {

--- a/Space-Zoologist/Assets/Scripts/Managers/GameManager.cs
+++ b/Space-Zoologist/Assets/Scripts/Managers/GameManager.cs
@@ -366,7 +366,6 @@ public class GameManager : MonoBehaviour
 
     private void InitialNeedSystemUpdate()
     {
-        m_foodSourceManager.LoadInitialFoods();
         this.UpdateAllNeedSystems();
         m_populationManager.UpdateAllGrowthConditions();
         TogglePause();


### PR DESCRIPTION
Removed FoodSourceManager.LoadInitialFoods() and reference to the function due to it being a duplicate to FoodSourceManager.Parse().

The bug was caused by calling both functions, leading to duplicated objects in FoodSourceCalculators.