### PR TITLE
Update resources in correct place on sellback

### DIFF
--- a/Space-Zoologist/Assets/Scripts/UI/Store/StoreSection.cs
+++ b/Space-Zoologist/Assets/Scripts/UI/Store/StoreSection.cs
@@ -113,7 +113,8 @@ public class StoreSection : MonoBehaviour
         }
         else
         {
-            storeItems[item].RemainingAmount += count;
+            this.ResourceManager.AddItem(item.ItemName, count);
+            //storeItems[item].RemainingAmount += count;
         }
     }
 

--- a/Space-Zoologist/Assets/Scripts/Y - Utils/MoveObject.cs
+++ b/Space-Zoologist/Assets/Scripts/Y - Utils/MoveObject.cs
@@ -193,8 +193,8 @@ public class MoveObject : MonoBehaviour
             LevelData.ItemData tileItemData = GameManager.Instance.LevelData.itemQuantities.Find(x => x.itemObject.ID.ToLower().Equals(objectToMove.name));
             sellBackCost = tileItemData.itemObject.Price;
         }
-        MoveButton.GetComponentInChildren<Text>().text = $"${moveCost}";
-        DeleteButton.GetComponentInChildren<Text>().text = $"${sellBackCost}";
+        MoveButton.GetComponentInChildren<Text>().text = "$0"; //$"${moveCost}"; These are set to 0 until we figure out the design for moveing and selling stuff
+        DeleteButton.GetComponentInChildren<Text>().text = "$0"; //$"${sellBackCost}";
     }
 
     private void UpdateMoveUIPosition()


### PR DESCRIPTION
Selling an item back would increment the value in the StoreSection but not in the actual ResourceManager. That is no longer the case