### PR TITLE
Bugfix

### DIFF
--- a/Space-Zoologist/Assets/Prefabs/NeedSystems.meta
+++ b/Space-Zoologist/Assets/Prefabs/NeedSystems.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 2f5e6e3931e7f8d4fbd5e0d344bcfcd2
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Space-Zoologist/Assets/Scripts/LevelData/LevelNavigator.cs
+++ b/Space-Zoologist/Assets/Scripts/LevelData/LevelNavigator.cs
@@ -6,7 +6,7 @@ using UnityEngine.SceneManagement;
 
 public class LevelNavigator : MonoBehaviour
 {
-
+    [SerializeField] SceneNavigator SceneNavigator = default;
     [SerializeField] LevelDataLoader LevelLoader = default;
     [SerializeField] GameObject LevelUIPrefab = default;
     [SerializeField] GameObject LevelContent = default;
@@ -28,7 +28,7 @@ public class LevelNavigator : MonoBehaviour
             newLevel.GetComponent<LevelUI>().InitializeLevelUI(level.Level);
             newLevel.GetComponent<Button>().onClick.AddListener(() => {
                 currentLevel.levelName = level.Level.SceneName;
-                SceneManager.LoadScene("MainLevel");
+                SceneNavigator.LoadLevel("MainLevel");
             });
             this.DisplayedLevels.Add(newLevel);
         }

--- a/Space-Zoologist/Assets/Scripts/LevelData/SceneNavigator.cs
+++ b/Space-Zoologist/Assets/Scripts/LevelData/SceneNavigator.cs
@@ -11,24 +11,14 @@ public class SceneNavigator : ScriptableObject
 
     public void LoadLevel(string levelName)
     {
+        GameManager.Instance?.HandleExitLevel();
         this.UpdateRecentlyLoadedLevel(levelName);
         SceneManager.LoadScene(levelName, LoadSceneMode.Single);
     }
 
     public void RestartLevel()
     {
-        SceneManager.LoadScene("MainLevel");
-    }
-
-    public void LoadNextLevel() {
-        for (int i = 0; i < Levels.Count; i++) {
-            if (Levels[i].SceneName == RecentlyLoadedLevel) {
-                // found current level, load the next one
-                LoadLevel(Levels[i + 1].SceneName);
-                return;
-            }
-        }
-        Debug.LogError("Scene Navigator: Did not find current level. Check if level name matches scene name.");
+        LoadLevel("MainLevel");
     }
 
     public void LoadMainMenu()

--- a/Space-Zoologist/Assets/Scripts/Managers/GameManager.cs
+++ b/Space-Zoologist/Assets/Scripts/Managers/GameManager.cs
@@ -561,6 +561,13 @@ public class GameManager : MonoBehaviour
         this.IngameUI.SetActive(false);
     }
 
+    public void HandleExitLevel() {
+        // Is not currently in level
+        if (SceneNavigator.RecentlyLoadedLevel != "MainLevel") return;
+
+        m_gridSystem.SetGridOverlay(false);
+    }
+
     public void HandleGameOver()
     {
         Pause();

--- a/Space-Zoologist/Assets/Scripts/UI/JournalSystems.meta
+++ b/Space-Zoologist/Assets/Scripts/UI/JournalSystems.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 3f7079a074ca5b743b8ad8bd8623fcb1
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Space-Zoologist/Assets/Scripts/Utils.meta
+++ b/Space-Zoologist/Assets/Scripts/Utils.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 592eba8783f0be64d8fe98b9ad62ab22
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 


### PR DESCRIPTION
- Drafting UI no longer retain after scene load

This is done by implementing GameManager.HandleExitLevel(), which is called when exiting a level (might want to expand on this function to reset more things).