### PR TITLE
Food can be moved to overlap with its current position

### DIFF
--- a/Space-Zoologist/Assets/Scripts/Managers/FoodSourceManager.cs
+++ b/Space-Zoologist/Assets/Scripts/Managers/FoodSourceManager.cs
@@ -66,9 +66,9 @@ public class FoodSourceManager : GridObjectManager
         return newFoodSourceGameObject;
     }
 
-    public GameObject CreateFoodSource(string foodsourceSpeciesID, Vector2 position)
+    public GameObject CreateFoodSource(string foodsourceSpeciesID, Vector2 position, int ttb = -1)
     {
-        return CreateFoodSource(GameManager.Instance.FoodSources[foodsourceSpeciesID], position);
+        return CreateFoodSource(GameManager.Instance.FoodSources[foodsourceSpeciesID], position, ttb);
     }
 
     public void DestroyFoodSource(FoodSource foodSource) {


### PR DESCRIPTION
When moving food, you can now place it at a location that would've overlapped with its original position.

KNOWN ISSUE: The tile highlight color doesn't update. This is due to the timing of when the food source is removed, but this is a good enough fix to make it into the build. I will work on this step next.