### PR TITLE
Separate SFX for unavailable items

### DIFF
--- a/Space-Zoologist/Assets/Scripts/UI/Store/StoreSection.cs
+++ b/Space-Zoologist/Assets/Scripts/UI/Store/StoreSection.cs
@@ -126,7 +126,7 @@ public class StoreSection : MonoBehaviour
     {
         if (!this.CanBuy(item))
         {
-            OnItemSelectionCanceled();
+            OnItemUnavailable();
             return;
         }
         AudioManager.instance.PlayOneShot(SFXType.Valid);
@@ -139,6 +139,11 @@ public class StoreSection : MonoBehaviour
         cursorItem.Stop(OnCursorItemClicked, OnCursorPointerDown, OnCursorPointerUp);
         AudioManager.instance?.PlayOneShot(SFXType.Cancel);
         GridSystem.ClearHighlights();
+    }
+
+    public virtual void OnItemUnavailable()
+    {
+        AudioManager.instance.PlayOneShot(SFXType.Unavailable);
     }
 
     public void OnCursorItemClicked(PointerEventData eventData)


### PR DESCRIPTION
Items that cannot be bought (usually because there is <= 0 in stock) now plays a different sound effect