### PR TITLE
Changed the rubric to use point values instead of percentages

### DIFF
--- a/Space-Zoologist/Assets/Scripts/Editor/Quiz/QuizTemplateEditor.cs
+++ b/Space-Zoologist/Assets/Scripts/Editor/Quiz/QuizTemplateEditor.cs
@@ -1,0 +1,24 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEditor;
+
+public class QuizTemplateEditor : Editor
+{
+    #region Editor Overrides
+    public override void OnInspectorGUI()
+    {
+        serializedObject.Update();
+
+        // Draw the default inspector
+        DrawDefaultInspector();
+
+        // Setup the template on the example quiz
+        SerializedProperty exampleQuiz = serializedObject.FindProperty(nameof(exampleQuiz));
+        SerializedProperty template = exampleQuiz.FindPropertyRelative(nameof(template));
+        template.objectReferenceValue = target;
+
+        serializedObject.ApplyModifiedProperties();
+    }
+    #endregion
+}

--- a/Space-Zoologist/Assets/Scripts/Editor/Quiz/QuizTemplateEditor.cs.meta
+++ b/Space-Zoologist/Assets/Scripts/Editor/Quiz/QuizTemplateEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ec652ffd201b80344800e4b613de2465
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Space-Zoologist/Assets/Scripts/Quiz/QuizGradingRubric.cs
+++ b/Space-Zoologist/Assets/Scripts/Quiz/QuizGradingRubric.cs
@@ -2,30 +2,24 @@
 using System.Collections.Generic;
 using UnityEngine;
 
-[CreateAssetMenu]
-public class QuizGradingRubric : ScriptableObject
+[System.Serializable]
+public class QuizGradingRubric
 {
     #region Private Editor Fields
     [SerializeField]
-    [Range(0f, 1f)]
-    [Tooltip("Percentage correct you must get to pass the important categories")]
-    private float percentToPassImportantQuestions;
+    [Tooltip("Points correct you must get to pass the important categories")]
+    private int scoreToPassImportantQuestions;
     [SerializeField]
-    [Range(0f, 1f)]
-    [Tooltip("Percentage correct you must get to pass the unimportant categories")]
-    private float percentToPassUnimportantQuestions;
+    [Tooltip("Points correct you must get to pass the unimportant categories")]
+    private int scoreToPassUnimportantQuestions;
     #endregion
 
     #region Public Methods
-    public bool PassedImportantQuestions(int score, int totalScore) => Grade(score, totalScore, percentToPassImportantQuestions);
-    public bool PassedUnimportantQuestions(int score, int totalScore) => Grade(score, totalScore, percentToPassUnimportantQuestions);
+    public bool PassedImportantQuestions(int score) => Grade(score, scoreToPassImportantQuestions);
+    public bool PassedUnimportantQuestions(int score) => Grade(score, scoreToPassUnimportantQuestions);
     #endregion
 
     #region Private Methods
-    private bool Grade(int score, int totalScore, float percent)
-    {
-        if (totalScore > 0) return ((float)score / totalScore) >= percent;
-        else return true;
-    }
+    private bool Grade(int score, int scoreToPass) => score >= scoreToPass;
     #endregion
 }

--- a/Space-Zoologist/Assets/Scripts/Quiz/QuizInstance.cs
+++ b/Space-Zoologist/Assets/Scripts/Quiz/QuizInstance.cs
@@ -91,16 +91,14 @@ public class QuizInstance
         }
         return score;
     }
-    public static bool PassedImportantQuestions(QuizTemplate template, int[] answers) => template.GradingRubric.PassedImportantQuestions(
-        ComputeScoreInImportantCategories(template, answers),
-        template.GetMaximumPossibleScoreInImportantCategories());
+    public static bool PassedImportantQuestions(QuizTemplate template, int[] answers) => template.GradingRubric
+        .PassedImportantQuestions(ComputeScoreInImportantCategories(template, answers));
     public static int ComputeScoreInUnimportantCategories(QuizTemplate template, int[] answers)
     {
         return ComputeItemizedScore(template, answers).TotalScore - ComputeScoreInImportantCategories(template, answers);
     }
-    public static bool PassedUnimportantQuestions(QuizTemplate template, int[] answers) => template.GradingRubric.PassedUnimportantQuestions(
-        ComputeScoreInUnimportantCategories(template, answers),
-        template.GetMaximumPossibleScoreInUnimportantCategories());
+    public static bool PassedUnimportantQuestions(QuizTemplate template, int[] answers) => template.GradingRubric
+        .PassedUnimportantQuestions(ComputeScoreInUnimportantCategories(template, answers));
     public static ItemizedQuizScore ComputeItemizedScore(QuizTemplate template, int[] answers)
     {
         ItemizedQuizScore itemizedScore = new ItemizedQuizScore();

--- a/Space-Zoologist/Assets/Scripts/Quiz/QuizTemplate.cs
+++ b/Space-Zoologist/Assets/Scripts/Quiz/QuizTemplate.cs
@@ -22,6 +22,12 @@ public class QuizTemplate : ScriptableObject
     [SerializeField]
     [Tooltip("Percentage to get correct to be considered a 'partial pass'")]
     private QuizGradingRubric gradingRubric;
+
+    [Space]
+
+    [SerializeField]
+    [Tooltip("Example quiz instance. Use this to test the parameters of this template")]
+    private QuizInstance exampleQuiz;
     #endregion
 
     #region Public Methods
@@ -59,8 +65,6 @@ public class QuizTemplate : ScriptableObject
             IEnumerable<QuizQuestion> questions = GetQuestionsWithCategory(category);
             // Initialize the max score
             int maxScore = 0;
-
-            // Check if the array is not null or empty
             foreach (QuizQuestion q in questions)
             {
                 maxScore += q.MaxPossibleScore;


### PR DESCRIPTION
This implements a fix requested by James, our writer.  The quizzes are not designed to use percentages, they're supposed to use exact point values, so I just changed the QuizGradingRubric easily enough and it is all set