### PR TITLE
level reload problem appears fixed

### DIFF
--- a/Space-Zoologist/Assets/Scripts/Notebook/UI/ConceptsCanvasUI.cs
+++ b/Space-Zoologist/Assets/Scripts/Notebook/UI/ConceptsCanvasUI.cs
@@ -111,10 +111,9 @@ public class ConceptsCanvasUI : NotebookUIChild
         // bool on the conversation manager is not set until AFTER these events are invoked
         // (We really should fix that...)
 
-
         // ugly fix for linking issue
-        //ConversationManager.OnConversationStarted += () => SetCameraPosition(true);
-        //ConversationManager.OnConversationEnded += () => SetCameraPosition(false);
+        ConversationManager.OnConversationStarted += SetCameraPositionWithDialogue;
+        ConversationManager.OnConversationEnded += SetCameraPositionWithoutDialogue;
         
         // Apply foldout state to the anchors when we start
         ApplyFoldoutState(foldoutToggle.isOn);
@@ -139,8 +138,8 @@ public class ConceptsCanvasUI : NotebookUIChild
     private void OnDestroy()
     {
         // causing issues in instantiation
-        //ConversationManager.OnConversationStarted -= () => SetCameraPosition(true);
-        //ConversationManager.OnConversationEnded -= () => SetCameraPosition(false);
+        ConversationManager.OnConversationStarted -= SetCameraPositionWithDialogue;
+        ConversationManager.OnConversationEnded -= SetCameraPositionWithoutDialogue;
     }
     #endregion
 
@@ -200,6 +199,8 @@ public class ConceptsCanvasUI : NotebookUIChild
             if (instance) instance.m_cameraController.Unlock();
         }
     }
+    private void SetCameraPositionWithDialogue() => SetCameraPosition(true);
+    private void SetCameraPositionWithoutDialogue() => SetCameraPosition(false);
     private void SetCameraPosition()
     {
         ConversationManager conversation = ConversationManager.Instance;


### PR DESCRIPTION
This branch should have a fix to an issue in the ConceptsCanvasUI script.  It subscribes to a static event, so it must unsubscribe when it is destroyed.  Not 100% sure that the issue is fixed since I never succeeded in reproducing it, so please test this out before merging.  There should be no errors when the dialogue turns on an off while the Concepts Canvas is open after reloading the scene