### PR TITLE
Fixes for ToggleGroupPickers onToggleStateChanged triggering twice on…

### DIFF
--- a/Space-Zoologist/Assets/Scripts/Y - Utils/UI/TogglePicker/AbstractToggleGroupPicker.cs
+++ b/Space-Zoologist/Assets/Scripts/Y - Utils/UI/TogglePicker/AbstractToggleGroupPicker.cs
@@ -71,7 +71,12 @@ public abstract class AbstractToggleGroupPicker : MonoBehaviour
     {
         foreach (AbstractTogglePicker picker in pickers)
         {
-            UnityAction<bool> listener = _ => onToggleStateChanged.Invoke();
+            //state check in order to prevent double invoke, one for previous toggle being deactivated and one for new toggle being activated
+            UnityAction<bool> listener = (bool val) =>
+            {
+                if (val)
+                    onToggleStateChanged.Invoke();
+            };
             // Remove then re-add the listener so it is not added twice
             picker.Toggle.onValueChanged.RemoveListener(listener);
             picker.Toggle.onValueChanged.AddListener(listener);


### PR DESCRIPTION
Fix for ToggleGroupPickers onToggleStateChanged triggering twice on state change
This fixes tab switch audio playing twice inside the build menu.