### PR TITLE
Fixed being able to inspect while placing tiles

### DIFF
--- a/Space-Zoologist/Assets/Scripts/UI/Inspector/Inspector.cs
+++ b/Space-Zoologist/Assets/Scripts/UI/Inspector/Inspector.cs
@@ -73,8 +73,14 @@ public class Inspector : MonoBehaviour
     /// </summary>
     public void Update()
     {
-        if (this.IsInInspectorMode && Input.GetMouseButtonDown(0))
+        if (this.IsInInspectorMode && Input.GetMouseButtonDown(0) && FindObjectOfType<StoreSection>().SelectedItem == null)
         {
+            //Deselect if over UI
+            if(EventSystem.current.IsPointerOverGameObject())
+            {
+                UnHighlightAll();
+                return;
+            }
             if (EventSystem.current.currentSelectedGameObject != null && EventSystem.current.currentSelectedGameObject.layer == 5)
             {
                 return;

--- a/Space-Zoologist/Assets/Scripts/UI/Store/StoreSection.cs
+++ b/Space-Zoologist/Assets/Scripts/UI/Store/StoreSection.cs
@@ -73,7 +73,6 @@ public class StoreSection : MonoBehaviour
     {
         // Try to get the raycaster in the parent
         raycaster = GetComponentInParent<GraphicRaycaster>();
-
         // Add the items to the store section
         LevelData levelData = GameManager.Instance.LevelData;
         foreach (LevelData.ItemData data in levelData.ItemQuantities)
@@ -132,11 +131,14 @@ public class StoreSection : MonoBehaviour
         AudioManager.instance.PlayOneShot(SFXType.Valid);
         cursorItem.Begin(item.Icon, OnCursorItemClicked, OnCursorPointerDown, OnCursorPointerUp);
         selectedItem = item;
+        //Reset inspector selection
+        GameManager.Instance.m_inspector.ResetSelection();
     }
 
     public virtual void OnItemSelectionCanceled()
     {
         cursorItem.Stop(OnCursorItemClicked, OnCursorPointerDown, OnCursorPointerUp);
+        selectedItem = null;
         AudioManager.instance?.PlayOneShot(SFXType.Cancel);
         GridSystem.ClearHighlights();
     }

--- a/Space-Zoologist/Assets/Scripts/Y - Utils/MoveObject.cs
+++ b/Space-Zoologist/Assets/Scripts/Y - Utils/MoveObject.cs
@@ -107,7 +107,8 @@ public class MoveObject : MonoBehaviour
 
                     // Select the food or animal at mouse position
                     GameObject SelectedObject = SelectGameObjectAtMousePosition();
-                    if (SelectedObject != null)
+                    //Cannot select through UI
+                    if (SelectedObject != null && !EventSystem.current.IsPointerOverGameObject())
                         objectToMove = SelectedObject;
                 }
             }


### PR DESCRIPTION
Added in checks to Inspector and MoveObject to prevent selecting through UI elements, and clearing selections on UI clicks