### PR TITLE
Day advance bug fixed

### DIFF
--- a/Space-Zoologist/Assets/Resources/LevelData/Level2/L2E1Data.asset
+++ b/Space-Zoologist/Assets/Resources/LevelData/Level2/L2E1Data.asset
@@ -62,6 +62,7 @@ MonoBehaviour:
   levelMusic: {fileID: 8300000, guid: 52df1fae1ea2840ef968ac5dcd11476e, type: 3}
   startingPositions:
   - {x: 1, y: 1, z: 0}
+  - {x: 21, y: 25, z: 0}
   startingConversation: {fileID: 7380740231151405539, guid: c22b6032a52825a448547299475acac5,
     type: 3}
   defaultConversation: {fileID: 674947355878461197, guid: 3124ca85bbd1c476498793667738a9e7,


### PR DESCRIPTION
The only issue was that Level2E1 needed a second starting position so that the EnclosureSystem script could find and flood-fill the enclosed island at the top right of the screen