### PR TITLE
Population no longer drops to zero

### DIFF
--- a/Space-Zoologist/Assets/Scripts/Plot/RPS/EnclosureSystem.cs
+++ b/Space-Zoologist/Assets/Scripts/Plot/RPS/EnclosureSystem.cs
@@ -207,6 +207,7 @@ public class EnclosureSystem : MonoBehaviour
     /// <remarks>
     /// This is using a flood fill (https://en.wikipedia.org/wiki/Flood_fill) to find enclosed areas.
     /// Assumptions: the reserve is bordered by walls
+    /// NOTE: this assumption does not hold up for some reserves, such as Level2E2 and Level2E3
     /// </remarks>
     public void UpdateEnclosedAreas(bool isUpdate = true)
     {

--- a/Space-Zoologist/Assets/Scripts/PopulationSystem/Population/Population.cs
+++ b/Space-Zoologist/Assets/Scripts/PopulationSystem/Population/Population.cs
@@ -99,11 +99,26 @@ public class Population : MonoBehaviour, Life
         enclosedPopulationCount = AnimalPopulation.Count;
         // Only counts animals that are in an enclosure that is completely enclosed
         foreach (GameObject animal in AnimalPopulation) {
-            //GameManager.Instance.m_enclosureSystem.UpdateEnclosedAreas (true);
-            //print (GameManager.Instance.m_enclosureSystem.GetEnclosedAreaByCellPosition (new Vector3Int ((int) animal.transform.position.x, (int) animal.transform.position.y, (int) animal.transform.position.z)));
-            if (!GameManager.Instance.m_enclosureSystem.GetEnclosedAreaByCellPosition (new Vector3Int ((int) animal.transform.position.x, (int) animal.transform.position.y, (int) animal.transform.position.z)).isEnclosed) 
+
+            // Get my grid position
+            Vector3Int myGridPosition = new Vector3Int(
+                (int)animal.transform.position.x,
+                (int)animal.transform.position.y,
+                (int)animal.transform.position.z);
+
+            // Get the enclosed area I'm enclosed in
+            EnclosedArea myArea = GameManager
+                .Instance
+                .m_enclosureSystem
+                .GetEnclosedAreaByCellPosition(myGridPosition);
+
+            // If the area is not enclosed,
+            // then reduce the number of enclosed animals
+            // WHY?!
+            // Simply commenting this out fixes a bug. Is there any reason for this at all?
+            if (!myArea.isEnclosed) 
             {
-                enclosedPopulationCount--;
+                // enclosedPopulationCount--;
             }
         }
         //Debug.Log ("Population Count: " + enclosedPopulationCount);


### PR DESCRIPTION
Before, the population would reduce the number of animals if the animal was in an enclosed area where isEnclosed returned false.  There is no obvious reason why this should be the case.  The structure of the code still exists but the part of the code that reduces the number of animals has been simply removed.  I would think that this could cause some unforseen issues, but some basic testing with population splitting / combining has not resulted in any problems