### PR TITLE
Walls are now  highlighted when placing tiles based on whether or not…

### DIFF
--- a/Space-Zoologist/Assets/Resources/LevelData/Level2/L2E1Data.asset
+++ b/Space-Zoologist/Assets/Resources/LevelData/Level2/L2E1Data.asset
@@ -16,7 +16,7 @@ MonoBehaviour:
   startingBalance: 500
   MapWidth: 29
   MapHeight: 29
-  WallBreakable: 0
+  WallBreakable: 1
   LevelObjectiveData: {fileID: 11400000, guid: 2a168e3451e51445bac9a9693b51c952, type: 2}
   foodSources:
   - {fileID: 11400000, guid: 4519d95eb0a9149afaba1c7e635c9b1c, type: 2}

--- a/Space-Zoologist/Assets/ScriptableObjects/Levels/CreativeMode.meta
+++ b/Space-Zoologist/Assets/ScriptableObjects/Levels/CreativeMode.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: fee82f7c609461b47a04fea90ba165bb
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Space-Zoologist/Assets/ScriptableObjects/Levels/Level0.meta
+++ b/Space-Zoologist/Assets/ScriptableObjects/Levels/Level0.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: a41c9c3bed0dcb4479b480772705f3e8
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Space-Zoologist/Assets/ScriptableObjects/Levels/Level1.meta
+++ b/Space-Zoologist/Assets/ScriptableObjects/Levels/Level1.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 119979b9f639bf542a8ba1475699b7af
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Space-Zoologist/Assets/ScriptableObjects/Levels/Level2.meta
+++ b/Space-Zoologist/Assets/ScriptableObjects/Levels/Level2.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 98323d15628443a44b1df6f7b85080d1
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Space-Zoologist/Assets/ScriptableObjects/Levels/Level3.meta
+++ b/Space-Zoologist/Assets/ScriptableObjects/Levels/Level3.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: c281ea8e5dc2398408084174427147db
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Space-Zoologist/Assets/ScriptableObjects/Levels/Level4.meta
+++ b/Space-Zoologist/Assets/ScriptableObjects/Levels/Level4.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 7914166ac80dfa34eb55d01d3d9ea032
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Space-Zoologist/Assets/ScriptableObjects/Levels/MapDesigner.meta
+++ b/Space-Zoologist/Assets/ScriptableObjects/Levels/MapDesigner.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 4d7444d67b7b12b43967561063867c87
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Space-Zoologist/Assets/Scripts/UI/Store/StoreSection.cs
+++ b/Space-Zoologist/Assets/Scripts/UI/Store/StoreSection.cs
@@ -58,12 +58,13 @@ public class StoreSection : MonoBehaviour
             if (!GridSystem.IsWithinGridBounds(mousePosition)) return;
 
             Vector3Int gridLocation = GridSystem.WorldToCell(mousePosition);
-            if (this.GridSystem.IsOnWall(gridLocation)) return;
 
             if (gridLocation.x != previousLocation.x || gridLocation.y != previousLocation.y)
             {
                 previousLocation = gridLocation;
                 GridSystem.ClearHighlights();
+                //Invalid if the level does not allow placing on walls
+                if (this.GridSystem.IsOnWall(gridLocation) && !GameManager.Instance.LevelData.WallBreakable) return;
                 GridSystem.updateVisualPlacement(gridLocation, selectedItem);
             }
         }


### PR DESCRIPTION
Walls are now highlighted when placing tiles based on whether or not the level data allows for it. If it is not allowed
then no highlight appears(potentially need a red highlight instead of no highlight?)
Code changes in StoreSection Update()

Level2E1 Data now correctly allows for breaking walls