### PR TITLE
Tile moving fixes

### DIFF
--- a/Space-Zoologist/Assets/ScriptableObjects/Levels.meta
+++ b/Space-Zoologist/Assets/ScriptableObjects/Levels.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: cadcb29c171d83a488c711b3ebe959f0
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Space-Zoologist/Assets/ScriptableObjects/Levels/CreativeMode.meta
+++ b/Space-Zoologist/Assets/ScriptableObjects/Levels/CreativeMode.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: fee82f7c609461b47a04fea90ba165bb
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Space-Zoologist/Assets/ScriptableObjects/Levels/Level0.meta
+++ b/Space-Zoologist/Assets/ScriptableObjects/Levels/Level0.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: a41c9c3bed0dcb4479b480772705f3e8
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Space-Zoologist/Assets/ScriptableObjects/Levels/Level1.meta
+++ b/Space-Zoologist/Assets/ScriptableObjects/Levels/Level1.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 119979b9f639bf542a8ba1475699b7af
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Space-Zoologist/Assets/ScriptableObjects/Levels/Level2.meta
+++ b/Space-Zoologist/Assets/ScriptableObjects/Levels/Level2.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 98323d15628443a44b1df6f7b85080d1
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Space-Zoologist/Assets/ScriptableObjects/Levels/Level3.meta
+++ b/Space-Zoologist/Assets/ScriptableObjects/Levels/Level3.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: c281ea8e5dc2398408084174427147db
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Space-Zoologist/Assets/ScriptableObjects/Levels/Level4.meta
+++ b/Space-Zoologist/Assets/ScriptableObjects/Levels/Level4.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 7914166ac80dfa34eb55d01d3d9ea032
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Space-Zoologist/Assets/ScriptableObjects/Levels/MapDesigner.meta
+++ b/Space-Zoologist/Assets/ScriptableObjects/Levels/MapDesigner.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 4d7444d67b7b12b43967561063867c87
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Space-Zoologist/Assets/Scripts/Plot/TileDataController.cs
+++ b/Space-Zoologist/Assets/Scripts/Plot/TileDataController.cs
@@ -1106,11 +1106,14 @@ public class TileDataController : MonoBehaviour
 
     public bool IsFoodPlacementValid(Vector3 mousePosition, Item selectedItem = null, FoodSourceSpecies species = null)
     {
+        return IsFoodPlacementValid(mousePosition, new Vector3Int(999, 999, 999), selectedItem, species);
+    }
+    public bool IsFoodPlacementValid(Vector3 mousePosition, Vector3Int blindSpot, Item selectedItem = null, FoodSourceSpecies species = null)
+    {
         if (selectedItem)
             species = GameManager.Instance.FoodSources[selectedItem.ID];
-
         Vector3Int gridPosition = WorldToCell(mousePosition);
-        bool tileCheck = CheckSurroundingTiles(gridPosition, species);
+        bool tileCheck = CheckSurroundingTiles(gridPosition, species, blindSpot);
         return tileCheck;
     }
 
@@ -1159,6 +1162,11 @@ public class TileDataController : MonoBehaviour
 
     private bool CheckSurroundingTiles(Vector3Int cellPosition, FoodSourceSpecies species)
     {
+        return CheckSurroundingTiles(cellPosition, species, new Vector3Int(999, 999, 999));
+    }
+
+    private bool CheckSurroundingTiles(Vector3Int cellPosition, FoodSourceSpecies species,Vector3Int blindSpot)
+    {
         Vector3Int pos;
         bool isValid = true;
         // Size is even, offset by 1
@@ -1172,7 +1180,8 @@ public class TileDataController : MonoBehaviour
                 pos = cellPosition;
                 pos.x += x;
                 pos.y += y;
-                if (!IsFoodPlacementValid(pos, species))
+                bool isInBlindSpot = pos.x >= blindSpot.x && pos.x <= blindSpot.x + species.Size.x - 1 && pos.y >= blindSpot.y && pos.y <= blindSpot.y + species.Size.y - 1;
+                if (!IsFoodPlacementValid(pos, species) && !isInBlindSpot)
                 {
                     isValid = false;
                     HighlightTile(pos, Color.red);

--- a/Space-Zoologist/Assets/Scripts/UI/LogSystem.cs
+++ b/Space-Zoologist/Assets/Scripts/UI/LogSystem.cs
@@ -97,10 +97,10 @@ public class LogSystem : MonoBehaviour
         {
             this.handleLog(EventType.NewEnclosedArea);
         });
-        this.eventManager.SubscribeToEvent(EventType.AtmosphereChange, () =>
+/*        this.eventManager.SubscribeToEvent(EventType.AtmosphereChange, () =>
         {
             this.handleLog(EventType.AtmosphereChange);
-        });
+        });*/
         this.eventManager.SubscribeToEvent(EventType.LiquidChange, () =>
         {
             this.handleLog(EventType.LiquidChange);
@@ -134,9 +134,9 @@ public class LogSystem : MonoBehaviour
             case EventType.NewEnclosedArea:
                 this.logNewCreation((EnclosedArea)EventManager.Instance.EventData);
                 break;
-            case EventType.AtmosphereChange:
+/*            case EventType.AtmosphereChange:
                 this.logAtmoesphereChange((EnclosedArea)EventManager.Instance.EventData);
-                break;
+                break;*/
             case EventType.LiquidChange:
                 this.logLiquidChange((Vector3Int)EventManager.Instance.EventData);
                 break;


### PR DESCRIPTION
Tile move map highlights now properly update when hovering over wall
Attempting to move food onto an invalid area will no longer cancel the move command
Moving food no longer internally removes and replaces the food in-place on unsuccessful move(replaecd by above behavior)
IsFoodPlacementValid now includes a parameter for a "blind spot", which is ignored when checking for validity of a food placement(blind spots will always be a valid position)
This is used for moving foods(ignores the initial food position when checking validity of the new position)