### PR TITLE
EventManager Population Invalid Cast fix

### DIFF
--- a/Space-Zoologist/Assets/Animals/Patterns/Scripts/FoodPathfinding.cs
+++ b/Space-Zoologist/Assets/Animals/Patterns/Scripts/FoodPathfinding.cs
@@ -10,7 +10,7 @@ public class FoodPathfinding : GeneralPathfinding
     protected override void EnterPattern(GameObject gameObject, AnimalData animalData)
     {
         Vector3Int[] destinations = GameManager.Instance.m_foodSourceManager.GetFoodSourcesLocationWithSpecies(FoodSpeciesName);
-        Vector3Int destination = new Vector3Int(-1,-1,-1);
+        Vector3Int destination = base.TileDataController.WorldToCell(gameObject.transform.position);
         if (destinations != null)
         {
             // Shuffle destinations
@@ -36,7 +36,8 @@ public class FoodPathfinding : GeneralPathfinding
             if (destination.Equals(new Vector3Int(-1, -1, -1)))
             {
                 int locationIndex = animalData.animal.PopulationInfo.random.Next(0, animalData.animal.PopulationInfo.AccessibleLocations.Count);
-                destination = animalData.animal.PopulationInfo.AccessibleLocations[locationIndex];
+                if(animalData.animal.PopulationInfo.AccessibleLocationsExist)
+                    destination = animalData.animal.PopulationInfo.AccessibleLocations[locationIndex];
             }
 
             AnimalPathfinding.PathRequestManager.RequestPath(base.TileDataController.WorldToCell(gameObject.transform.position), destination, animalData.animal.MovementController.AssignPath, animalData.animal.PopulationInfo.Grid);

--- a/Space-Zoologist/Assets/Animals/Patterns/Scripts/GeneralPathfinding.cs
+++ b/Space-Zoologist/Assets/Animals/Patterns/Scripts/GeneralPathfinding.cs
@@ -10,7 +10,7 @@ public class GeneralPathfinding : BehaviorPattern
 
     protected override void EnterPattern(GameObject gameObject, AnimalData animalData)
     {
-        Vector3Int destination;
+        Vector3Int destination = base.TileDataController.WorldToCell(gameObject.transform.position);
         if (Destination.Equals(ItemRegistry.Category.Tile))
         {
             destination = base.TileDataController.FindClosestLiquidSource(animalData.animal.PopulationInfo, gameObject);
@@ -18,7 +18,8 @@ public class GeneralPathfinding : BehaviorPattern
         else
         {
             int locationIndex = animalData.animal.PopulationInfo.random.Next(0, animalData.animal.PopulationInfo.AccessibleLocations.Count);
-            destination = animalData.animal.PopulationInfo.AccessibleLocations[locationIndex];
+            if (animalData.animal.PopulationInfo.AccessibleLocationsExist)
+                destination = animalData.animal.PopulationInfo.AccessibleLocations[locationIndex];
         }
         AnimalPathfinding.PathRequestManager.RequestPath(base.TileDataController.WorldToCell(gameObject.transform.position), destination, animalData.animal.MovementController.AssignPath, animalData.animal.PopulationInfo.Grid);
     }

--- a/Space-Zoologist/Assets/ScriptableObjects/Levels.meta
+++ b/Space-Zoologist/Assets/ScriptableObjects/Levels.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: cadcb29c171d83a488c711b3ebe959f0
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Space-Zoologist/Assets/ScriptableObjects/Levels/CreativeMode.meta
+++ b/Space-Zoologist/Assets/ScriptableObjects/Levels/CreativeMode.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: fee82f7c609461b47a04fea90ba165bb
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Space-Zoologist/Assets/ScriptableObjects/Levels/Level0.meta
+++ b/Space-Zoologist/Assets/ScriptableObjects/Levels/Level0.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: a41c9c3bed0dcb4479b480772705f3e8
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Space-Zoologist/Assets/ScriptableObjects/Levels/Level1.meta
+++ b/Space-Zoologist/Assets/ScriptableObjects/Levels/Level1.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 119979b9f639bf542a8ba1475699b7af
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Space-Zoologist/Assets/ScriptableObjects/Levels/Level2.meta
+++ b/Space-Zoologist/Assets/ScriptableObjects/Levels/Level2.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 98323d15628443a44b1df6f7b85080d1
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Space-Zoologist/Assets/ScriptableObjects/Levels/Level3.meta
+++ b/Space-Zoologist/Assets/ScriptableObjects/Levels/Level3.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: c281ea8e5dc2398408084174427147db
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Space-Zoologist/Assets/ScriptableObjects/Levels/Level4.meta
+++ b/Space-Zoologist/Assets/ScriptableObjects/Levels/Level4.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 7914166ac80dfa34eb55d01d3d9ea032
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Space-Zoologist/Assets/ScriptableObjects/Levels/MapDesigner.meta
+++ b/Space-Zoologist/Assets/ScriptableObjects/Levels/MapDesigner.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 4d7444d67b7b12b43967561063867c87
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Space-Zoologist/Assets/Scripts/Managers/CursorManager.cs
+++ b/Space-Zoologist/Assets/Scripts/Managers/CursorManager.cs
@@ -10,8 +10,8 @@ public class CursorManager : MonoBehaviour
 
     void Start()
     {
-        EventManager.Instance.SubscribeToEvent(EventType.InspectorToggled, () => {
-                bool inspecting = (bool) EventManager.Instance.EventData;
+        EventManager.Instance.SubscribeToEvent(EventType.InspectorToggled, (eventData) => {
+                bool inspecting = (bool) eventData;
                 Cursor.SetCursor((inspecting ? CursorIconInspector : null), inspecting ? CursorHotspot : Vector2.zero, CursorMode.Auto);
                 });
     }

--- a/Space-Zoologist/Assets/Scripts/Managers/EventSystem/EventManager.cs
+++ b/Space-Zoologist/Assets/Scripts/Managers/EventSystem/EventManager.cs
@@ -22,18 +22,18 @@ public enum EventType {
 /// </summary>
 public class Publisher
 { 
-    public event Action Handlers;
+    public event Action<object> Handlers;
 
-    public void PublishTheEvent()
+    public void PublishTheEvent(object eventArgs)
     {
         // Invoke the action when it is not null
-        Handlers?.Invoke();
+        Handlers?.Invoke(eventArgs);
     }
 
     public void UnSubscribeAllMethods()
     {
         // Removes each action associates to this handler
-        foreach (Action handler in Handlers.GetInvocationList())
+        foreach (Action<object> handler in Handlers.GetInvocationList())
         {
             Handlers -= handler;
         }
@@ -42,7 +42,7 @@ public class Publisher
     public string PrintInvocationList()
     {
         string str = "Invocation list:";
-        foreach (Action handler in Handlers.GetInvocationList())
+        foreach (Action<object> handler in Handlers.GetInvocationList())
         {
             str += $"\n\tTarget: {handler.Target}, Method: {handler.Method.Name}";
         }
@@ -64,12 +64,6 @@ public class EventManager : MonoBehaviour
 {
     private static EventManager instance;
     private Dictionary<EventType, Publisher> eventPublishers = new Dictionary<EventType, Publisher>();
-    private object eventData = null;
-
-    // Holds a reference to the invoker (for the log system)
-    // TODO Consider safety issues with this reference 
-    public object EventData => this.eventData;
-
 
     public static EventManager Instance => EventManager.instance;
 
@@ -110,8 +104,7 @@ public class EventManager : MonoBehaviour
     /// <param name="eventType">Type of the event that just happens</param>
     public void InvokeEvent(EventType eventType, object eventData)
     {
-        this.eventData = eventData;
-        this.eventPublishers[eventType].PublishTheEvent();
+        this.eventPublishers[eventType].PublishTheEvent(eventData);
     }
 
     /// <summary>
@@ -119,16 +112,27 @@ public class EventManager : MonoBehaviour
     /// </summary>
     /// <param name="eventType">The event that suscripber is interested in</param>
     /// <param name="action">What action to be triggered when event happens</param>
-    public void SubscribeToEvent(EventType eventType, Action handler)
+    public void SubscribeToEvent(EventType eventType, Action<object> handler)
     {
         this.eventPublishers[eventType].Handlers += handler;
+    }
+
+    /// <summary>
+    /// Wrapper delegate for event listeners that take no parameters
+    /// </summary>
+    /// <param name="eventType"></param>
+    /// <param name="handler"></param>
+    public void SubscribeToEvent(EventType eventType, Action handler)
+    {
+        Action<object> handlerWrapper = (args) => handler();
+        this.eventPublishers[eventType].Handlers += handlerWrapper;
     }
 
     /// <summary>
     /// Unsubscribes to an event
     /// </summary>
     /// <remarks>Forget to unsubcribe would cause errors</remarks>
-    public void UnsubscribeToEvent(EventType eventType, Action handler)
+    public void UnsubscribeToEvent(EventType eventType, Action<object> handler)
     {
         this.eventPublishers[eventType].Handlers -= handler;
     }

--- a/Space-Zoologist/Assets/Scripts/Managers/GameManager.cs
+++ b/Space-Zoologist/Assets/Scripts/Managers/GameManager.cs
@@ -335,9 +335,9 @@ public class GameManager : MonoBehaviour
         }
 
         // Add the population to related objective if not seen before
-        EventManager.Instance.SubscribeToEvent(EventType.NewPopulation, () =>
+        EventManager.Instance.SubscribeToEvent(EventType.NewPopulation, (eventData) =>
         {
-            Population population = (Population)EventManager.Instance.EventData;
+            Population population = (Population)eventData;
             this.RegisterWithSurvivalObjectives(population);
         });
         this.UpdateObjectivePanel();

--- a/Space-Zoologist/Assets/Scripts/Managers/GameOverController.cs
+++ b/Space-Zoologist/Assets/Scripts/Managers/GameOverController.cs
@@ -64,9 +64,9 @@ public class GameOverController : MonoBehaviour
             });
         }
     }
-    private void OnPopulationExtinct()
+    private void OnPopulationExtinct(object eventData)
     {
-        Population population = EventManager.Instance.EventData as Population;
+        Population population = eventData as Population;
         // Count the number of animals that can still be placed in the enclosure
         int animalsRemainingToPlace = GameManager.Instance.m_resourceManager
             .CheckRemainingResource(population.species);

--- a/Space-Zoologist/Assets/Scripts/Plot/RPS/ReservePartitionManager.cs
+++ b/Space-Zoologist/Assets/Scripts/Plot/RPS/ReservePartitionManager.cs
@@ -69,7 +69,7 @@ public class ReservePartitionManager : MonoBehaviour
         populationAccessibleLiquidCompositions = new Dictionary<Population, List<float[]>>();
         populationAccessibleLiquidLocations = new Dictionary<Population, List<Vector3Int>>();
 
-        EventManager.Instance.SubscribeToEvent(EventType.PopulationExtinct, () => this.RemovePopulation((Population)EventManager.Instance.EventData));
+        EventManager.Instance.SubscribeToEvent(EventType.PopulationExtinct, (eventData) => this.RemovePopulation((Population)eventData));
     }
 
     /// <summary>

--- a/Space-Zoologist/Assets/Scripts/Plot/TileDataController.cs
+++ b/Space-Zoologist/Assets/Scripts/Plot/TileDataController.cs
@@ -73,8 +73,8 @@ public class TileDataController : MonoBehaviour
                     changedTilesNoWall.Add(tilePosition);
             }
 
-            EventManager.Instance.SubscribeToEvent (EventType.StoreToggled, () => {
-                if ((bool) EventManager.Instance.EventData) {
+            EventManager.Instance.SubscribeToEvent (EventType.StoreToggled, (eventData) => {
+                if ((bool)eventData) {
                     // Invoke event and pass the changed tiles that are not walls
                     EventManager.Instance.InvokeEvent (EventType.TerrainChange, changedTilesNoWall);
                 } else {

--- a/Space-Zoologist/Assets/Scripts/PopulationSystem/Population/Population.cs
+++ b/Space-Zoologist/Assets/Scripts/PopulationSystem/Population/Population.cs
@@ -21,6 +21,7 @@ public class Population : MonoBehaviour
 
     public AnimalPathfinding.Grid Grid { get; private set; }
     public List<Vector3Int> AccessibleLocations { get; private set; }
+    public bool AccessibleLocationsExist { get => AccessibleLocations.Count > 0; }
 
     private float animatorSpeed = 1f;
     private float overlaySpeed = 1f;
@@ -203,7 +204,9 @@ public class Population : MonoBehaviour
                 float populationDecreaseAmount = this.Count * this.GrowthCalculator.ChangeRate * -1;
                 for (int i = 0; i < populationDecreaseAmount; ++i)
                 {
-                    this.RemoveAnimal(this.AnimalPopulation[i]);
+                    if (this.AnimalPopulation.Count == 0)
+                        break;
+                    this.RemoveAnimal(this.AnimalPopulation[0]);
                 }
             }
         }

--- a/Space-Zoologist/Assets/Scripts/PopulationSystem/Population/PopulationManager.cs
+++ b/Space-Zoologist/Assets/Scripts/PopulationSystem/Population/PopulationManager.cs
@@ -30,7 +30,7 @@ public class PopulationManager : MonoBehaviour
         }
 
         EventManager.Instance.SubscribeToEvent(EventType.PopulationExtinct, this.RemovePopulation);
-        EventManager.Instance.SubscribeToEvent(EventType.StoreToggled, () => { if (!(bool) EventManager.Instance.EventData) UpdateAccessibleLocations(); });
+        EventManager.Instance.SubscribeToEvent(EventType.StoreToggled, (eventData) => { if (!(bool) eventData) UpdateAccessibleLocations(); });
     }
 
     private AnimalSpecies LoadSpecies(string name)
@@ -84,13 +84,13 @@ public class PopulationManager : MonoBehaviour
         return copiedBehaviors;
     }
 
-    private void RemovePopulation()
+    private void RemovePopulation(object eventData)
     {
-        if (!ExistingPopulations.Contains((Population)EventManager.Instance.EventData))
+        if (!ExistingPopulations.Contains((Population)eventData))
         {
             return;
         }
-        this.ExistingPopulations.Remove((Population)EventManager.Instance.EventData);
+        this.ExistingPopulations.Remove((Population)eventData);
     }
 
     /// <summary>

--- a/Space-Zoologist/Assets/Scripts/UI/LogSystem.cs
+++ b/Space-Zoologist/Assets/Scripts/UI/LogSystem.cs
@@ -76,75 +76,57 @@ public class LogSystem : MonoBehaviour
     {
         this.eventManager = EventManager.Instance;
 
-        // Subscribe to the events
-        this.eventManager.SubscribeToEvent(EventType.PopulationCountChange, () =>
+        var handleLogEvents = new EventType[]
         {
-            this.handleLog(EventType.PopulationCountChange);
-        });
-        this.eventManager.SubscribeToEvent(EventType.PopulationExtinct, () =>
+            EventType.PopulationCountChange,
+            EventType.PopulationExtinct,
+            EventType.NewPopulation,
+            EventType.NewFoodSource,
+            EventType.NewEnclosedArea,
+            EventType.LiquidChange,
+            EventType.FoodSourceChange,
+            EventType.TerrainChange
+        };
+
+        foreach(var logEventType in handleLogEvents)
         {
-            this.handleLog(EventType.PopulationExtinct);
-        });
-        this.eventManager.SubscribeToEvent(EventType.NewPopulation, () =>
-        {
-            this.handleLog(EventType.NewPopulation);
-        });
-        this.eventManager.SubscribeToEvent(EventType.NewFoodSource, () =>
-        {
-            this.handleLog(EventType.NewFoodSource);
-        });
-        this.eventManager.SubscribeToEvent(EventType.NewEnclosedArea, () =>
-        {
-            this.handleLog(EventType.NewEnclosedArea);
-        });
-/*        this.eventManager.SubscribeToEvent(EventType.AtmosphereChange, () =>
-        {
-            this.handleLog(EventType.AtmosphereChange);
-        });*/
-        this.eventManager.SubscribeToEvent(EventType.LiquidChange, () =>
-        {
-            this.handleLog(EventType.LiquidChange);
-        });
-        this.eventManager.SubscribeToEvent(EventType.FoodSourceChange, () =>
-        {
-            this.handleLog(EventType.FoodSourceChange);
-        });
-        this.eventManager.SubscribeToEvent(EventType.TerrainChange, () =>
-        {
-            this.handleLog(EventType.TerrainChange);
-        });
+            this.eventManager.SubscribeToEvent(logEventType, (eventData) =>
+            {
+                this.handleLog(logEventType,eventData);
+            });
+        }
     }
 
-    private void handleLog(EventType eventType)
+    private void handleLog(EventType eventType, object eventData)
     {
         switch(eventType)
         {
             case EventType.PopulationCountChange:
-                this.logPopulationCountChange(((Population population, bool increased)) EventManager.Instance.EventData);
+                this.logPopulationCountChange(((Population population, bool increased)) eventData);
                 break;
             case EventType.PopulationExtinct:
-                this.logPopulationExtinct((Population)EventManager.Instance.EventData);
+                this.logPopulationExtinct((Population)eventData);
                 break;
             case EventType.NewPopulation:
-                this.logNewCreation((Population)EventManager.Instance.EventData);
+                this.logNewCreation((Population)eventData);
                 break;
             case EventType.NewFoodSource:
-                this.logNewCreation((FoodSource)EventManager.Instance.EventData);
+                this.logNewCreation((FoodSource)eventData);
                 break;
             case EventType.NewEnclosedArea:
-                this.logNewCreation((EnclosedArea)EventManager.Instance.EventData);
+                this.logNewCreation((EnclosedArea)eventData);
                 break;
 /*            case EventType.AtmosphereChange:
                 this.logAtmoesphereChange((EnclosedArea)EventManager.Instance.EventData);
                 break;*/
             case EventType.LiquidChange:
-                this.logLiquidChange((Vector3Int)EventManager.Instance.EventData);
+                this.logLiquidChange((Vector3Int)eventData);
                 break;
             case EventType.FoodSourceChange:
-                this.logFoodSourceChanged((FoodSource)EventManager.Instance.EventData);
+                this.logFoodSourceChanged((FoodSource)eventData);
                 break;
             case EventType.TerrainChange:
-                this.logTerrainChange((List<Vector3Int>)EventManager.Instance.EventData);
+                this.logTerrainChange((List<Vector3Int>)eventData);
                 break;
             default:
                 Debug.Assert(true, $"LogSystem does not knows how to handle {eventType} yet");

--- a/Space-Zoologist/Assets/Scripts/UI/Store/SellingManager.cs
+++ b/Space-Zoologist/Assets/Scripts/UI/Store/SellingManager.cs
@@ -41,7 +41,7 @@ public class SellingManager : MonoBehaviour
 
         IsSelling = false;
         // stop selling when store opens
-        EventManager.Instance.SubscribeToEvent(EventType.StoreToggled, () => { if ((bool) EventManager.Instance.EventData) this.IsSelling = false; });
+        EventManager.Instance.SubscribeToEvent(EventType.StoreToggled, (eventData) => { if ((bool) eventData) this.IsSelling = false; });
     }
 
     // Update is called once per frame


### PR DESCRIPTION
Event Manager changes
eventData now passed through the publisher directly instead of being cached in the EventManager singleton for listeners to access in a roundabout way
Added a wrapper around listeners that dont take parameters (might cause issues with printinvocationlist)

